### PR TITLE
Add kerning options

### DIFF
--- a/src/html-processor.ts
+++ b/src/html-processor.ts
@@ -10,14 +10,9 @@ class HTMLProcessor {
   private transformFunctions: TransformFunction[]
   private options: TypeSetttingOptions
 
-  constructor(transformFunctions: TransformFunction[], options: Partial<TypeSetttingOptions> = {}) {
+  constructor(transformFunctions: TransformFunction[], options: TypeSetttingOptions) {
     this.transformFunctions = transformFunctions
-    this.options = {
-      addWbrToHtml: true,
-      addThinSpaceToHtml: true,
-      thinSpaceWidth: '50%',
-      ...options,
-    }
+    this.options = options
   }
 
   /**

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,7 +6,11 @@
  * @param nextNodeValue - 次のノードの値（存在する場合）。存在しない場合は空文字列を想定。
  * @return 変換後の文字列。
  */
-export type TransformFunction = (currentNodeValue: string, nextNodeValue: string, options: TypeSetttingOptions) => string
+export type TransformFunction = (
+  currentNodeValue: string,
+  nextNodeValue: string,
+  options: TypeSetttingOptions
+) => string
 
 /**
  * 組版処理に関する設定オプションの型定義です。
@@ -29,4 +33,20 @@ export interface TypeSetttingOptions {
    * 例えば'20%'と指定すると、THIN SPACEは通常のスペースの20%の幅になります。
    */
   thinSpaceWidth: string
+
+  /**
+   * カーニングを適用するためのルールのリスト。
+   * 各ルールは、特定の文字ペア間に適用されるカーニング値を指定します。
+   */
+  kerning: KerningRule[]
+}
+
+/**
+ * カーニングルールを定義するインターフェース。
+ * between: 文字ペアを定義します。
+ * value: 適用するカーニング値（1000 = 1em）を指定します。
+ */
+export interface KerningRule {
+  between: [string, string]
+  value: string | number
 }

--- a/src/utils-tags.ts
+++ b/src/utils-tags.ts
@@ -1,4 +1,5 @@
 const classnamePrefix = 'typeset'
+const uiIgnore = 'user-select:none;" aria-hidden="true" data-nosnippet=""'
 
 /**
  * `<wbr>`タグはHTML文書内で単語の区切りを示し、必要に応じて改行の挿入を許可するタグです。
@@ -12,7 +13,21 @@ const wbr = '<wbr>'
  */
 const thinSpace = (width: string) => {
   const THIN_SPACE = String.fromCharCode(0x2009) // U+2009 THIN SPACE
-  return `<span style="font-size: ${width}; user-select:none;" aria-hidden="true" data-nosnippet="">${THIN_SPACE}</span>`
+  const classname: string = classnamePrefix + '-thin-space'
+  return `<span class="${classname}" style="font-size: ${width}; ${uiIgnore}>${THIN_SPACE}</span>`
+}
+
+/**
+ * 指定された文字にカーニング（文字間隔調整）を適用します。
+ *
+ * @param char - カーニングを適用する文字。
+ * @param value - カーニング値（千分率）。例: 1000 は 1em のカーニングを意味します。
+ * @return カーニング適用後のHTMLコンテンツ。
+ */
+const applyKerning = (char: string, value: number) => {
+  const emValue = value / 1000 / 2 + 'em'
+  const classname: string = classnamePrefix + '-kerning'
+  return `${char}<span class="${classname}" style="margin: ${emValue}; ${uiIgnore}></span>`
 }
 
 /**
@@ -46,4 +61,4 @@ const applyNoBreakStyle = (segment: string) => {
   return `<span class="${classname}" style="letter-spacing: 0">${segment}</span>`
 }
 
-export { wbr, thinSpace, applyWbrStyle, applyLatinClass, applyNoBreakStyle }
+export { wbr, thinSpace, applyKerning, applyWbrStyle, applyLatinClass, applyNoBreakStyle }

--- a/src/utils-tags.ts
+++ b/src/utils-tags.ts
@@ -11,7 +11,7 @@ const wbr = '<wbr>'
  * @param width - THIN SPACEの幅。
  * @return スタイル適用されたTHIN SPACEを含むspanタグ。
  */
-const thinSpace = (width: string) => {
+const thinSpace = (width: string): string => {
   const THIN_SPACE = String.fromCharCode(0x2009) // U+2009 THIN SPACE
   const classname: string = classnamePrefix + '-thin-space'
   return `<span class="${classname}" style="font-size: ${width}; ${uiIgnore}>${THIN_SPACE}</span>`
@@ -24,7 +24,7 @@ const thinSpace = (width: string) => {
  * @param value - カーニング値（千分率）。例: 1000 は 1em のカーニングを意味します。
  * @return カーニング適用後のHTMLコンテンツ。
  */
-const applyKerning = (char: string, value: number) => {
+const applyKerning = (char: string, value: number): string => {
   const emValue = value / 1000 / 2 + 'em'
   const classname: string = classnamePrefix + '-kerning'
   return `${char}<span class="${classname}" style="margin: ${emValue}; ${uiIgnore}></span>`
@@ -35,7 +35,7 @@ const applyKerning = (char: string, value: number) => {
  * @param text - スタイルを適用するテキスト。
  * @return スタイル適用されたテキストを含むspanタグ。
  */
-const applyWbrStyle = (text: string) => {
+const applyWbrStyle = (text: string): string => {
   return `<span style="word-break: keep-all; overflow-wrap: anywhere;">${text}</span>`
 }
 
@@ -45,7 +45,7 @@ const applyWbrStyle = (text: string) => {
  * @param classname - 適用するクラス名。デフォルトは 'typeset-latin'。
  * @return クラス適用されたセグメントを含むspanタグ。
  */
-const applyLatinClass = (segment: string) => {
+const applyLatinClass = (segment: string): string => {
   const classname: string = classnamePrefix + '-latin'
   return `<span class="${classname}">${segment}</span>`
 }
@@ -56,7 +56,7 @@ const applyLatinClass = (segment: string) => {
  * @param classname - 適用するクラス名。デフォルトは 'typeset-no-breaks'。
  * @return スタイル適用されたセグメントを含むspanタグ。
  */
-const applyNoBreakStyle = (segment: string) => {
+const applyNoBreakStyle = (segment: string): string => {
   const classname: string = classnamePrefix + '-no-breaks'
   return `<span class="${classname}" style="letter-spacing: 0">${segment}</span>`
 }

--- a/tests/apply-style.test.ts
+++ b/tests/apply-style.test.ts
@@ -1,45 +1,81 @@
 import { applyStyleToSegment } from '../src/apply-style'
+import { TypeSetttingOptions } from '../src/types'
 
 describe('applyStyleToSegment', () => {
+  const options: TypeSetttingOptions = {
+    addWbrToHtml: true,
+    addThinSpaceToHtml: true,
+    thinSpaceWidth: '50%',
+    kerning: [
+      {
+        between: ['す', '。'],
+        value: '-80',
+      },
+    ],
+  }
+
   it("applies letter-spacing style to separation prohibited characters '──'", () => {
-    const segment = '──'
+    const current = '──'
+    const next = ''
     const expected = '<span class="typeset-no-breaks" style="letter-spacing: 0">──</span>'
-    expect(applyStyleToSegment(segment)).toEqual(expected)
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
   })
 
   it("does not change styling for full-width symbol '「'", () => {
-    const segment = '「'
+    const current = '「'
+    const next = ''
     const expected = '「'
-    expect(applyStyleToSegment(segment)).toEqual(expected)
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
   })
 
   it("does not change styling for hiragana 'こんにちは'", () => {
-    const segment = 'こんにちは'
+    const current = 'こんにちは'
+    const next = ''
     const expected = 'こんにちは'
-    expect(applyStyleToSegment(segment)).toEqual(expected)
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
   })
 
   it("does not change styling for kanji '日本語'", () => {
-    const segment = '日本語'
+    const current = '日本語'
+    const next = ''
     const expected = '日本語'
-    expect(applyStyleToSegment(segment)).toEqual(expected)
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
   })
 
   it("applies 'latin' class to English words 'English'", () => {
-    const segment = 'English'
+    const current = 'English'
+    const next = ''
     const expected = '<span class="typeset-latin">English</span>'
-    expect(applyStyleToSegment(segment)).toEqual(expected)
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
   })
 
   it("applies 'latin' class to half-width numbers '28'", () => {
-    const segment = '28'
+    const current = '28'
+    const next = ''
     const expected = '<span class="typeset-latin">28</span>'
-    expect(applyStyleToSegment(segment)).toEqual(expected)
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
   })
 
   it("applies 'latin' class to half-width symbol ':'", () => {
-    const segment = ':'
+    const current = ':'
+    const next = ''
     const expected = '<span class="typeset-latin">:</span>'
-    expect(applyStyleToSegment(segment)).toEqual(expected)
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
+  })
+
+  it("adds kerning tag after 'で'", () => {
+    const current = 'す'
+    const next = '。'
+    const expected =
+      'す<span class="typeset-kerning" style="margin: -0.04em; user-select:none;" aria-hidden="true" data-nosnippet=""></span>'
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
+  })
+
+  it("adds kerning tag after 'で'", () => {
+    const current = 'です。'
+    const next = 'その'
+    const expected =
+      'です<span class="typeset-kerning" style="margin: -0.04em; user-select:none;" aria-hidden="true" data-nosnippet=""></span>。'
+    expect(applyStyleToSegment(current, next, options)).toEqual(expected)
   })
 })

--- a/tests/insert-separators.test.ts
+++ b/tests/insert-separators.test.ts
@@ -1,10 +1,16 @@
-import insertSeparatorsToText, { generateSegments, addSeparatorsToSegment, shouldAddWbr, shouldAddThinSpace } from '../src/insert-separators'
+import insertSeparatorsToText, {
+  generateSegments,
+  addSeparatorsToSegment,
+  shouldAddWbr,
+  shouldAddThinSpace,
+} from '../src/insert-separators'
 import { wbr, thinSpace } from '../src/utils-tags'
 
 const options = {
   addWbrToHtml: true,
   addThinSpaceToHtml: true,
   thinSpaceWidth: '50%',
+  kerning: [],
 }
 
 const space = thinSpace(options.thinSpaceWidth)
@@ -21,7 +27,23 @@ describe('insertSeparators', () => {
 describe('generateSegments', () => {
   it('generates an array of text segments from a sentence, using word granularity', () => {
     const src = '──「こんにちは。」日本語とEnglish、晴れ・28度。'
-    const expected = ['─', '─', '「', 'こんにちは', '。', '」', '日本語', 'と', 'English', '、', '晴れ', '・', '28', '度', '。']
+    const expected = [
+      '─',
+      '─',
+      '「',
+      'こんにちは',
+      '。',
+      '」',
+      '日本語',
+      'と',
+      'English',
+      '、',
+      '晴れ',
+      '・',
+      '28',
+      '度',
+      '。',
+    ]
     expect(generateSegments(src)).toEqual(expected)
   })
 })


### PR DESCRIPTION
input option
```
  const options: TypeSetttingOptions = {
    kerning: [
      {
        between: ['す', '。'],
        value: '-80',
      },
    ],
  }
```

input value
```
なのです。
```

output
```
なのです<span class="typeset-kerning" style="margin: -0.04em; user-select:none;" aria-hidden="true" data-nosnippet=""></span>。
```