### PR TITLE
Add space to latenRegex

### DIFF
--- a/src/util-regex.ts
+++ b/src/util-regex.ts
@@ -1,7 +1,7 @@
 /**
  * ラテン文字、数字、基本的な記号類
  */
-export const latinRegex = /[\p{scx=Latin}0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]+/u
+export const latinRegex = /[\p{scx=Latin}0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~\s]+/u
 
 /**
  * 日本語


### PR DESCRIPTION
<img width="759" alt="Screenshot 2024-02-09 at 1 05 36" src="https://github.com/yamatoiizuka/palt-typesetting/assets/47804982/4fe921d3-65d5-4b08-99c9-f5ed462ca4a5">
スペースを .typeset-laten でラップしなかった際、Safari 16.2 でスペースに下線がかからない現象に遭遇したため、latenRegex にスペースを追加するように変更した。