### PR TITLE
Enhance: Enable access to Parcel development server from devices on local network

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,8 @@
     "prebuild": "npm run clean:dist && npm run copy:public",
     "clean:dist": "rm -rf dist && mkdir dist",
     "copy:public": "cp -r public/* dist/",
-    "build": "parcel build ./src/index.html --no-cache"
+    "build": "parcel build ./src/index.html --no-cache",
+    "serve": "parcel ./src/index.html --host 0.0.0.0 --no-cache"
   },
   "author": {
     "name": "Yamato Iizuka",
@@ -20,6 +21,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "palt-typesetting": "file:../"
+    "palt-typesetting": "file:../src"
   }
 }


### PR DESCRIPTION
デモにおいて、
```
scripts: {
  "serve": "parcel ./src/index.html --host 0.0.0.0 --no-cache"
}
```
の追加により、ローカルネットワークを共有している他のデバイス（スマートフォンなど）でも挙動を確認できるようにした。

接続方法は、
`http://<YOUR IP ADDRESS>:1234`