### PR TITLE
Install dependency for node environment

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "palt-typesetting": "file:../"
+        "palt-typesetting": "file:../src",
+        "path-browserify": "^1.0.1"
       },
       "devDependencies": {
         "parcel": "^2.11.0",
@@ -45,6 +46,7 @@
     "../palt-typesetting": {
       "extraneous": true
     },
+    "../src": {},
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
@@ -3218,7 +3220,7 @@
       "dev": true
     },
     "node_modules/palt-typesetting": {
-      "resolved": "..",
+      "resolved": "../src",
       "link": true
     },
     "node_modules/parcel": {
@@ -3282,6 +3284,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "palt-typesetting": "file:../src"
+    "palt-typesetting": "file:../src",
+    "path-browserify": "^1.0.1"
   }
 }


### PR DESCRIPTION
こちらのビルドエラーを受けて
```
@parcel/resolver-default: Node builtin polyfill "path-browserify/" is not 
installed, but auto install is disabled.

  /home/runner/work/palt-typesetting/palt-typesetting/node_modules/jsdom/lib/api.js:2:22
    1 | "use strict";
  > 2 | const path = require("path");
  >   |                      ^^^^^^ used here
    3 | const fs = require("fs").promises;
    4 | const vm = require("vm");

  💡 Install the "path-browserify/" package with your package manager, and 
```