### PR TITLE
Remove unnecessary serve command

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,8 +8,7 @@
     "prebuild": "npm run clean:dist && npm run copy:public",
     "clean:dist": "rm -rf dist && mkdir dist",
     "copy:public": "cp -r public/* dist/",
-    "build": "parcel build ./src/index.html --no-cache",
-    "serve": "parcel ./src/index.html --host 0.0.0.0 --no-cache"
+    "build": "parcel build ./src/index.html --no-cache"
   },
   "author": {
     "name": "Yamato Iizuka",


### PR DESCRIPTION
host の指定なしでも、外部端末から`http://<YOUR IP>:1234` でアクセスできることがわかり、`serve` コマンドを削除しました。