### PR TITLE
Reduce flickering during web font loading

### DIFF
--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -67,9 +67,6 @@ h1 {
  * 英数のみのスタイリング
  */
 .typeset-latin {
-  /* フォントのウェイト */
-  font-weight: 200;
-
   /* フォントの拡大・縮小 */
   font-size: 104%;
 
@@ -87,6 +84,13 @@ h1 {
 
   /* 文字の細らせ・太らせ */
   -webkit-text-stroke: 0.014em var(--color-main);
+
+  /*
+   * フォールバックフォントのウェイト：
+   * Web フォント読み込み時のチラつきを低減するための設定
+   * -webkit-text-stroke の値に応じて変更
+   */
+  font-weight: 200;
 }
 
 .en-section {

--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -27,7 +27,7 @@ body {
 
 article {
   font-feature-settings: 'palt';
-  font-weight: 300;
+  font-weight: 400;
   font-size: 1.2rem;
   line-height: 2;
   letter-spacing: 0.12em;
@@ -40,7 +40,7 @@ article {
 }
 
 h1 {
-  font-weight: 300;
+  font-weight: 400;
   margin: 0;
   font-size: 1.5rem;
 }
@@ -67,6 +67,9 @@ h1 {
  * 英数のみのスタイリング
  */
 .typeset-latin {
+  /* フォントのウェイト */
+  font-weight: 200;
+
   /* フォントの拡大・縮小 */
   font-size: 104%;
 


### PR DESCRIPTION
デモコードで、
```css
.typeset-latin {
  -webkit-text-stroke: 0.014em var(--color-main);
}
```
による、Web フォント読み込み時のチラつきを低減するため、
フォールバックフォントの日本語と英数のウェイト差をあらかじめつけておく変更を加えた。